### PR TITLE
upgrade   flutter_quill: ^9.1.1

### DIFF
--- a/lib/src/delta_markdown_decoder.dart
+++ b/lib/src/delta_markdown_decoder.dart
@@ -2,7 +2,8 @@ import 'dart:collection';
 import 'dart:convert';
 
 import 'package:flutter_quill/flutter_quill.dart'
-    show Attribute, AttributeScope, Delta, LinkAttribute;
+    show Attribute, AttributeScope, LinkAttribute;
+import 'package:flutter_quill/quill_delta.dart';
 
 import 'ast.dart' as ast;
 import 'document.dart';

--- a/lib/src/delta_markdown_encoder.dart
+++ b/lib/src/delta_markdown_encoder.dart
@@ -2,7 +2,8 @@ import 'dart:convert';
 
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:flutter_quill/flutter_quill.dart'
-    show Attribute, AttributeScope, BlockEmbed, Delta, DeltaIterator, Style;
+    show Attribute, AttributeScope, BlockEmbed, Style;
+import 'package:flutter_quill/quill_delta.dart';
 
 class DeltaMarkdownEncoder extends Converter<String, String> {
   static const _lineFeedAsciiCode = 0x0A;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   args: ^2.4.2
   charcode: ^1.3.1
   collection: ^1.15.0
-  flutter_quill: ^9.0.0-dev-7
+  flutter_quill: ^9.1.1
 
 dev_dependencies:
   build_runner: ^2.4.6


### PR DESCRIPTION
To fix:
```
Error (Xcode): ../../../.pub-cache/hosted/pub.dev/delta_markdown_converter-0.0.3-dev/lib/src/delta_markdown_decoder.dart:27:8: Error: Type 'Delta' not found.

```